### PR TITLE
feat(docs): internal architecture & rendering flow documentation

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -1,0 +1,125 @@
+# Architecture & Data Flow (my-http-server)
+
+> WHY: Provide a precise, implementation-aligned overview so new contributors can reason about
+> change impact (config, rendering, HTTP) without diving through all modules. English + 中文混合
+> 以便團隊成員快速吸收。
+
+## High-Level Overview
+
+Pipeline (dynamic markdown request):
+
+```
+HTTP Request --> actix-web route --> path resolution (http_ext)
+  -> if .md => read file (fs) -> md2html(parser) -> markdown_ppp (AST -> HTML fragment)
+      -> templating.get_engine + get_context -> inject body + extras -> mystical_runic render
+  -> respond HTML
+```
+
+Static file path is identical until the extension check branches into `NamedFile::open_async`.
+
+### Module Responsibilities
+
+| Module               | Responsibility                                            | WHY (Rationale)                                              |
+| -------------------- | --------------------------------------------------------- | ------------------------------------------------------------ |
+| `cofg`               | Load + cache configuration with optional hot reload       | Avoid per-request IO; enable dev tweak cycle                 |
+| `parser::templating` | Engine construction & context variable inference          | Keep md2html lean; centralize type inference + env expansion |
+| `parser::markdown`   | TOC creation & batch/utility conversion, markdown parsing | Separate tooling from request hot path                       |
+| `parser` (mod)       | Orchestrate md→HTML→template pipeline                     | Single entry simplifying handlers                            |
+| `http_ext`           | Per-request cached derived values                         | Prevent repeated percent-decode & path joins                 |
+| `main`               | Composition of HTTP server & routes                       | Keep side effects (init, server build) contained             |
+| `error`              | Unified error type & responder impl                       | Propagate with `?` without HTTP coupling                     |
+
+## Configuration Flow
+
+1. First access calls `Cofg::new()` → `OnceCell<RwLock<Cofg>>` filled from `cofg.yaml` (or embedded default).
+2. Subsequent `Cofg::new()` calls clone existing value (cheap, small struct) → no disk IO.
+3. If caller uses `Cofg::get(true)` AND `templating.hot_reload = true`, a fresh struct is reloaded.
+4. `force_refresh()` (tests) bypasses hot_reload guard.
+
+中文：大多數情況以快取設定服務請求；只有熱重載模式才允許明確要求重新載入，以確保生產環境穩定與效能。
+
+## Template Engine Lifecycle
+
+- Single global `OnceCell<RwLock<TemplateEngine>>`.
+- Normal mode: first build enables bytecode cache; subsequent calls reuse.
+- Hot reload mode: every `get_engine` call rebuilds engine (cost accepted for dev ergonomics).
+- Context is always fresh (stateless); dynamic variables are re-parsed each request.
+
+## Markdown Rendering Flow
+
+```
+md2html(md, cfg, extra_vars)
+  engine = get_engine(cfg)
+  ctx = get_context(cfg)
+  for v in extra_vars: set_context_value(ctx, v)
+  ast = parser_md(md)
+  fragment = markdown_ppp::render_html(ast)
+  ctx.body = fragment
+  template = engine.compile_to_bytecode("html-t.templating") // cached in engine layer
+  output = engine.render(template, ctx)
+```
+
+Errors during compile or render are converted into `AppError::Template` and bubbled up.
+
+## TOC Generation
+
+`get_toc` walks `public_path` for extensions in `toc.ext`, percent-encodes path (except '/') and builds a Markdown list. This is converted to HTML only when needed (index fallback) or via optional tooling `_make_toc`.
+
+## Request Handling Logic
+
+1. `index` route:
+   - If `public/index.html` exists → serve raw (user override wins).
+   - Else build TOC markdown → `md2html` → serve.
+2. `/{filename:.*}` route:
+   - Resolve disk path via `cached_public_req_path`.
+   - 404 if missing (serve custom meta/404.html if present).
+   - If extension `.md` → read file & `md2html` with `path:` variable.
+   - Else static file streaming.
+
+### Per-request Caches (http_ext)
+
+- Decoded URI (trim leading '/')
+- Filename Path (PathBuf from route param)
+- Public absolute path
+- Markdown extension boolean
+
+WHY: Small computed values reused across logging, branching, and file reads.
+
+## Hot Reload Semantics
+
+| Feature              | No Hot Reload              | Hot Reload Enabled                         |
+| -------------------- | -------------------------- | ------------------------------------------ |
+| Config (`Cofg::new`) | Always cached              | Same unless caller forces with `get(true)` |
+| Template Engine      | Reused across requests     | Rebuilt each call                          |
+| Template Files       | Only read at first compile | Updated every request due to rebuild       |
+| Context Vars         | Recomputed per render      | Same                                       |
+
+中文：hot_reload 僅擴散到「需要即時反映變更」的層級（模板與設定），避免不必要的全域重建。
+
+## Error Propagation Strategy
+
+Deep functions return `AppResult<T>`; route handlers pattern-match and translate to HTTP codes (200, 404, 500). `AppError` implements `Responder` which ensures uncaught errors still produce a 500 with logging.
+
+## Concurrency Considerations
+
+- `RwLock` minimizes contention: reads dominate (clone config / read engine); writes occur only on forced reload or hot reload.
+- Template engine rebuild path obtains a write lock briefly; acceptable due to development-only usage.
+
+## Future Extension Points
+
+| Area          | Suggestion                                               | Notes                                    |
+| ------------- | -------------------------------------------------------- | ---------------------------------------- |
+| Watcher       | Optional file watcher triggering `Cofg::force_refresh()` | Add feature flag to avoid runtime cost   |
+| Pre-render    | CLI command to batch md→html for static hosting          | Reuse `_md2html_all()`                   |
+| Caching layer | Add rendered HTML cache keyed by file mtime              | Avoid repeated parsing for popular pages |
+| Streaming     | Output chunked HTML while rendering large docs           | Requires incremental printer support     |
+| Metrics       | Add request/render timing histogram                      | Expose via /metrics (Prometheus)         |
+
+## Security Notes
+
+- Paths are joined against configured `public_path`; no explicit sanitization of `..`—consider enforcing canonicalization & prefix check before access.
+- Template variables from config are trusted; if extended to user input, sanitize before `set_context_value`.
+
+## Summary
+
+System prefers simplicity & per-request clarity over aggressive caching except where global reuse is nearly free (config, engine). Hot reload mode purposefully narrows extra cost to development scenarios.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,45 @@
+use std::process::Command;
+use std::path::Path;
+use std::env::var;
+
+fn main() {
+  #[allow(clippy::single_element_loop)]
+  for path in ["build.rs"] {
+    println!("cargo:rerun-if-changed={path}");
+  }
+
+  let commit_hash = {
+    if Path::new("./.git").exists() {
+      let output = Command::new("git")
+        .arg("rev-parse")
+        .arg("HEAD")
+        .output()
+        .expect("build.rs: Failed to execute command");
+
+      if output.status.success() {
+        let commit_hash_str = String::from_utf8_lossy(&output.stdout);
+        commit_hash_str.trim().to_string()
+      } else {
+        println!("cargo::warning=build.rs: Git command failed with output: {output:#?}");
+        String::from("unknown")
+      }
+    } else {
+      println!("cargo::warning=build.rs: No .git directory found, skipping git versioning");
+      String::from("unknown")
+    }
+  };
+
+  println!(
+    "cargo:rustc-env=VERSION={}({} Profile)-{commit_hash}({})",
+    var("CARGO_PKG_VERSION").unwrap(),
+    var("PROFILE").unwrap(),
+    match var("ACTIONS_ID") {
+      Ok(id) => format!("actions/runs/{id}"),
+      Err(std::env::VarError::NotPresent) => "Local".to_string(),
+      Err(e) => {
+        println!("cargo::error=build.rs: {e}");
+        "unknown".to_string()
+      }
+    }
+  );
+}

--- a/config-templating-map.md
+++ b/config-templating-map.md
@@ -1,0 +1,85 @@
+# Config ↔ Template & Code Usage Map
+
+> WHY: Provide a single reference mapping `cofg.yaml` fields to their runtime effect / code touch
+> points. 中文：快速了解設定欄位如何影響程式行為。
+
+## Top-Level
+
+| Field                        | Type              | Code Reference                                           | Effect                                                                     |
+| ---------------------------- | ----------------- | -------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `addrs.ip`                   | string            | `main.rs:build_server` via `CofgAddrs`                   | Bind listen IP                                                             |
+| `addrs.port`                 | u16               | `main.rs:build_server`                                   | Bind listen port                                                           |
+| `middleware.normalize_path`  | bool              | `main.rs:build_server`                                   | Conditionally wraps `NormalizePath(Trim)`                                  |
+| `middleware.compress`        | bool              | `main.rs:build_server`                                   | Conditionally wraps `Compress` middleware                                  |
+| `middleware.logger.enabling` | bool              | `main.rs:build_server`                                   | Enables `middleware::Logger`                                               |
+| `middleware.logger.format`   | string            | `main.rs:build_server`                                   | Passed to `Logger::new` (adds custom url replacement)                      |
+| `templating.value`           | list<string>      | `parser/templating.rs:get_context` & `set_context_value` | Provides dynamic template variables (`name:value`)                         |
+| `templating.hot_reload`      | bool              | `cofg::get` (reload gate), `templating::get_engine`      | Allows disk reload of config / per-request rebuild of template engine      |
+| `toc.path`                   | string (relative) | `markdown.rs:get_toc`, `_make_toc`, `main.rs:index`      | Location (within public) for generated TOC HTML target & base dir for scan |
+| `toc.ext`                    | list<string>      | `markdown.rs:get_toc`                                    | File extensions considered for TOC entries                                 |
+| `public_path`                | string            | many: `http_ext`, `markdown`, `main`                     | Root directory for content lookup                                          |
+
+## `templating.value` Mini DSL
+
+Format: `name:value`
+
+Resolution order:
+
+1. Split at first ':'
+2. If value starts with `env:` then fetch environment variable
+3. Try bool parse → try i64 parse → fallback string
+
+Examples:
+
+```yaml
+# cofg.yaml snippet
+templating:
+  value:
+    - "feature_x:true" # bool => context.bool(feature_x)=true
+    - "build:42" # number => context.number(build)=42
+    - "git_hash:env:GIT" # env lookup
+    - "title:My Docs" # string
+```
+
+## Hot Reload Semantics
+
+| Flag                    | What Triggers Reload                              | Affects                                 |
+| ----------------------- | ------------------------------------------------- | --------------------------------------- |
+| `templating.hot_reload` | `Cofg::get(true)` calls & every `get_engine` call | Config struct; template engine instance |
+
+中文：若已啟用 hot_reload，程式碼顯式呼叫 `get(true)` 才會重讀設定；模板引擎則每次重新建立，確保檔案修改立即生效。
+
+## Derived Template Variables (Implicit)
+
+| Name             | Source                                                 | Description                               |
+| ---------------- | ------------------------------------------------------ | ----------------------------------------- |
+| `server-version` | `env!(CARGO_PKG_VERSION)`                              | Crate package version                     |
+| `body`           | `md2html` pipeline                                     | Injected rendered HTML fragment           |
+| `path`           | Route handlers supply (`path:<req path>` / `path:toc`) | Current logical path for templating logic |
+
+## Touch Points Summary
+
+```text
+cofg::get / new --> (read cofg.yaml once; optional reload)
+  |         \
+  |          -> main.rs (server bind, middleware toggles)
+  |          -> templating::get_engine (hot reload decision)
+  |          -> templating::get_context (variable list)
+  |          -> markdown::get_toc (public_path + toc.*)
+  |          -> http_ext (public_path joins)
+```
+
+## Validation & Safety Notes
+
+- Missing `cofg.yaml` → program writes embedded default (BUILD_COFG)
+- Unknown `templating.value` entry without ':' is ignored (safe no-op)
+- `toc.path` must have a parent directory; error otherwise
+- `public_path` is created at startup if absent
+
+## Suggestions
+
+| Area       | Improvement                                                                              |
+| ---------- | ---------------------------------------------------------------------------------------- |
+| Schema     | Optional explicit types (YAML map) for templating values to allow richer numeric support |
+| Validation | Add startup validation pass logging warnings for impossible paths / duplicates           |
+| Security   | Enforce `public_path` canonical prefix on resolved request paths to mitigate traversal   |

--- a/developer-guide.md
+++ b/developer-guide.md
@@ -1,0 +1,152 @@
+# Developer Guide (深入開發指南)
+
+> Goal: Accelerate onboarding with practical tasks & mental models. 目標：快速進入狀況。
+
+## 1. Quick Start
+
+```bash
+cargo run
+# visit http://127.0.0.1:8080 (or configured ip/port)
+```
+
+If `cofg.yaml` missing it is auto-created from embedded default.
+
+## 2. Key Mental Models
+
+| Concept         | Think Of It As                      | Notes                                      |
+| --------------- | ----------------------------------- | ------------------------------------------ |
+| Config (`Cofg`) | Immutable snapshot (cheap clone)    | Reload only under hot reload explicit call |
+| Template Engine | Heavy object w/ bytecode cache      | Rebuilt each request only in hot_reload    |
+| md2html         | Pure transformation + template wrap | No global state modification               |
+| http_ext caches | Per-request memoization             | Avoid redoing string/path work             |
+
+## 3. Common Tasks
+
+### Add New Template Variable
+
+1. Append string to `templating.value` in `cofg.yaml` (e.g. `- "docs_mode:true"`)
+2. (Optional) Use `env:` prefix for environment injection
+3. Reference in `meta/html-t.templating` via `{{ docs_mode }}`
+4. Enable `templating.hot_reload: true` during development to avoid restart
+
+### Expose Config Field to Templates
+
+If it's a dynamic toggle better as `templating.value`. Only add new struct fields when the value has strong type semantics or needed by Rust code.
+
+### Add Middleware
+
+`build_server` in `main.rs` composes middleware under conditional wrappers. Pattern:
+
+```rust
+.wrap(middleware::Condition::new(cfg_flag, middleware::SomeMiddleware::new()))
+```
+
+### Batch Convert Markdown (static export)
+
+Call tooling helpers (manually or via future CLI command):
+
+- `_md2html_all()`
+- `_make_toc()`
+
+### Change 404 Page
+
+Edit `meta/404.html`. No restart needed if only static file; templates not involved.
+
+## 4. Testing Strategy
+
+| Layer          | Test Type                       | Example                            |
+| -------------- | ------------------------------- | ---------------------------------- |
+| Config load    | Unit                            | Default values, hot reload gating  |
+| Templating     | Unit                            | `set_context_value` parsing matrix |
+| Markdown parse | Unit                            | Edge syntax constructs             |
+| md2html        | Integration                     | Template error propagation         |
+| HTTP           | Integration (actix test server) | Markdown vs static path branching  |
+
+Use `cargo nextest run` for faster & nicer output.
+
+## 5. Style & Conventions
+
+| Area              | Convention                                                                               |
+| ----------------- | ---------------------------------------------------------------------------------------- |
+| Error propagation | Prefer `?` returning `AppResult<T>`                                                      |
+| Logging           | `debug!` for flow; `warn!` for recoverable issues; `error!` for template/render failures |
+| File naming       | Keep modules short (`cofg`, `parser`, `http_ext`)                                        |
+| Internal tooling  | Prefix with `_` to mark non-route usage                                                  |
+
+## 6. Extending Functionality
+
+### Add CLI Flags
+
+Edit `src/cofg/cli.rs` (not shown here) then merge into config via `build_config_from_cli`.
+
+### Add New Output Format
+
+Keep `md2html` pure; create new function (e.g. `md2pdf`) that parallels pipeline & reuses `parser_md`.
+
+### Add Live Watcher
+
+Potential crate: `notify`. Flow:
+
+1. Spawn background task on startup when feature enabled
+2. Watch `cofg.yaml` & `meta/` & `public/`
+3. On change: `Cofg::force_refresh()` or invalidate HTML cache (future)
+
+### Implement HTML Render Cache
+
+Pseudo-code:
+
+```rust
+struct RenderCacheKey { path: PathBuf, mtime: SystemTime }
+// HashMap<RenderCacheKey, Arc<String>>
+```
+
+Look up before `read_to_string`; if mtime changed re-render.
+
+## 7. Performance Checklist
+
+| Check                 | Action                              |
+| --------------------- | ----------------------------------- |
+| High CPU parse        | Add render cache                    |
+| Slow TOC              | Precompute at startup or memoize    |
+| Template thrash (dev) | Confirm hot_reload only when needed |
+
+## 8. Security Considerations
+
+| Risk                                  | Mitigation Idea                     |
+| ------------------------------------- | ----------------------------------- |
+| Path traversal (`..`)                 | Canonicalize & enforce prefix guard |
+| Large untrusted files                 | Add size cap before reading         |
+| Template injection (future user vars) | Escape or whitelist variable names  |
+
+## 9. Troubleshooting
+
+| Symptom                  | Likely Cause             | Fix                                  |
+| ------------------------ | ------------------------ | ------------------------------------ |
+| Template changes ignored | hot_reload false         | Set `templating.hot_reload: true`    |
+| Config not updating      | Using `Cofg::new()` only | Call `Cofg::get(true)` in admin path |
+| 404 Always               | Wrong `public_path`      | Check or recreate directory          |
+| Garbled UTF-8            | Source file encoding     | Ensure UTF-8 without BOM             |
+
+## 10. Future CLI Ideas
+
+| Command       | Purpose                          |
+| ------------- | -------------------------------- |
+| `--export`    | Batch produce static HTML site   |
+| `--list-vars` | Print resolved templating values |
+| `--validate`  | Run config + path validations    |
+
+## 11. Contribution Flow
+
+1. Fork / branch from `dev`
+2. Add or update tests under `src/test/`
+3. Run `cargo fmt` & `cargo clippy -- -D warnings` (add if not in CI)
+4. Run `cargo nextest run`
+5. Open PR describing rationale (reference doc section if relevant)
+
+## 12. Glossary
+
+| Term           | Meaning                                                                           |
+| -------------- | --------------------------------------------------------------------------------- |
+| Hot Reload     | Rebuild template engine & allow config re-read (on explicit demand) every request |
+| Bytecode Cache | Precompiled template bytecode stored in memory for faster render                  |
+| TOC            | Table of Contents (generated markdown listing)                                    |

--- a/key-functions.md
+++ b/key-functions.md
@@ -1,0 +1,92 @@
+# Key Functions & Design Rationale
+
+> WHY: Capture the intent behind non-trivial functions to reduce future refactor risk and avoid
+> cargo-cult duplication. 中文補充說明輔助溝通。
+
+## Cofg
+
+### `Cofg::new()`
+
+Alias for `get(false)`. Keeps hot path call sites short. Avoids accidental `force_reload` usage that might degrade performance.
+
+### `Cofg::get(force_reload)`
+
+Conditional reload (only if `hot_reload` true). Ensures production config stability while allowing dev refresh.
+
+### `Cofg::force_refresh()`
+
+Bypasses hot_reload guard; test-only / tooling. Not used in runtime code to prevent hidden overhead.
+
+## Templating
+
+### `set_context_value(context, data)`
+
+String mini DSL: `name:value` processed with simple inference.
+
+- Pros: Flexible, no schema explosion
+- Cons: Limited types (bool, i64, string) — deliberate for predictability
+- Edge Handling: Malformed strings (no ':') ignored silently (safe failure)
+
+### `get_context(cfg)`
+
+Always returns a fresh context (stateless). Ensures no cross-request contamination, simpler mental model vs global mutable context.
+
+### `get_engine(cfg)`
+
+Single global engine reused unless `hot_reload`. Rebuild trade-off is deliberate: dev immediacy > raw throughput in that mode.
+
+## Markdown & TOC
+
+### `parser_md(input)`
+
+Encapsulates third-party crate usage & config. Future changes (e.g. enabling extensions) localized here.
+
+### `get_toc(cfg)`
+
+On-demand walk each time index fallback is requested. Simplicity over caching; frequency expected low relative to individual page hits. Percent-encodes except '/'; ensures link stability across OS path separators.
+
+### `_md2html_all()` / `_make_toc()` (underscored)
+
+Tooling helpers. Not part of server initialization to keep startup constant time.
+
+## Rendering Pipeline
+
+### `md2html(md, cfg, extra_vars)`
+
+Orchestrates: engine retrieval → context creation → AST parse → HTML body injection → template render.
+
+- Accepts owned `md` to avoid clone cost from file read
+- Extra variables appended after config-driven ones so request-scoped keys (e.g. path) can override if needed
+- Error surfaced as `AppError::Template` for consistent responder logic
+
+## HTTP Layer
+
+### `index` handler
+
+Dual-mode: serve custom `index.html` OR synthesized TOC. Users can introduce bespoke landing page without configuration toggle.
+
+### `main_req` handler
+
+Unified route for all other paths (pattern captures). Single branching logic keeps complexity bounded: existence → markdown? → dynamic render else static file. Custom 404 path tries meta/404.html first to allow styled errors.
+
+## Request Extension Cache (http_ext)
+
+Four derived values precomputed lazily; each micro-optimization prevents repeated computation where logger & handlers might need same values. Memory footprint small (a few strings & paths) per request.
+
+## Error Model
+
+Single `AppError` covers IO / glob / template / markdown / config / other. Downstream complexity shrinks: functions return `AppResult<T>` and rely on `?` propagation. Actix Responder impl ensures consistent 500 behavior for uncaught cases.
+
+## Hot Reload Scope
+
+Only touches config reload & template engine rebuild. Markdown content is always freshly read; no caching ensures the latest file changes are visible regardless of hot_reload.
+
+## Potential Future Evolutions
+
+| Area | Option | Considerations |
+|------|--------|----------------|
+| md cache | LRU keyed by (path, mtime) | Avoid reparse for high-traffic pages; need invalidation |
+| partials | Extend DSL for `include:` variables | Keep syntax minimal or move to structured YAML section |
+| search | Pre-index headings for quick lookup | Likely requires async task & incremental updates |
+| auth | Middleware gating private docs | Ensure config reload semantics include auth rules |
+

--- a/performance-cache.md
+++ b/performance-cache.md
@@ -1,0 +1,73 @@
+# Performance & Caching Notes
+
+> WHY: Document current perf characteristics & low-risk improvement knobs. 中文：描述現有快取與潛在優化點。
+
+## 1. Existing Caches
+
+| Layer                  | Mechanism                          | Scope        | Hit Path                           | Miss Cost                  |
+| ---------------------- | ---------------------------------- | ------------ | ---------------------------------- | -------------------------- |
+| Config                 | `OnceCell<RwLock<Cofg>`            | Global       | Almost every request (Cofg::new)   | Disk read + deserialize    |
+| Template Engine        | `OnceCell<RwLock<TemplateEngine>>` | Global       | Each markdown render               | Engine construction        |
+| Request Derived Values | `HttpRequest.extensions`           | Per-request  | Multiple handler branches + logger | Recompute path decode/join |
+| Bytecode Cache         | mystical_runic internal flag       | Engine-level | Template compile                   | Parse + compile template   |
+
+## 2. Hot Reload Costs
+
+| Feature                           | Extra Overhead When Enabled   | Rationale                      |
+| --------------------------------- | ----------------------------- | ------------------------------ |
+| Config force reload (`get(true)`) | One lock write + disk read    | Developer explicit action only |
+| Engine rebuild per render         | Lock write + new engine alloc | Immediate template reflection  |
+
+中文：hot_reload 僅在開發期啟用，成本有限且局限在模板與設定重建。
+
+## 3. Potential Bottlenecks
+
+| Area                          | Symptom                               | Profiling Signal                   |
+| ----------------------------- | ------------------------------------- | ---------------------------------- |
+| Large markdown parse          | High CPU time in `markdown_ppp`       | Flamegraph heavy parse stack       |
+| Frequent identical md renders | Repeated parse & render for same file | High count of identical file reads |
+| Huge public tree TOC          | Slow `/` when index absent            | Long glob walk time                |
+
+## 4. Improvement Options (Incremental)
+
+| Option                                          | Type             | Effort | Risk                            | Expected Gain                             |
+| ----------------------------------------------- | ---------------- | ------ | ------------------------------- | ----------------------------------------- |
+| HTML output cache keyed by (abs path, mtime)    | Runtime feature  | Medium | Need invalidation correctness   | Avoid repeat parse for popular docs       |
+| Async pre-warm cache on startup (scan recent N) | Optional feature | Medium | Startup delay                   | Faster first hits                         |
+| TOC memoize with directory mtime hash           | Runtime feature  | Low    | Stale if partial changes missed | Faster `/` under big trees                |
+| Config validation pass (log warnings)           | Startup          | Low    | Minimal                         | Early detection of misconfig              |
+| Rate limit engine rebuild logging               | Dev UX           | Low    | None                            | Cleaner logs when saving template rapidly |
+
+## 5. Suggested Roadmap
+
+1. Add simple in-memory LRU (e.g. `hashbrown + linked-hash`) for rendered pages
+2. Add quick `public_path` traversal to find largest / most popular candidate files (heuristic: size)
+3. Expose feature flags (Cargo `--features perf-cache`) to keep base binary minimal
+
+## 6. Edge Considerations
+
+| Edge                           | Handling Today           | Note                            |
+| ------------------------------ | ------------------------ | ------------------------------- |
+| File deleted mid-request       | Read error → 500         | Acceptable; infrequent race     |
+| Large single file (> a few MB) | Fully buffered           | Could stream in future          |
+| Path traversal (`..`)          | Not explicitly sanitized | Consider canonical prefix check |
+
+## 7. Micro Benchmarks (Hypothetical Setup)
+
+To evaluate improvements, measure:
+
+- Cold vs warm md2html (same file) time (ns/op)
+- Throughput under concurrency (wrk / bombardier) with mixed static + md
+- Latency added by hot_reload vs disabled
+
+## 8. Non-Goals (Currently)
+
+| Item                                 | Reason                                        |
+| ------------------------------------ | --------------------------------------------- |
+| Persistent cache across restarts     | Complexity > benefit for lightweight use case |
+| Distributed cache                    | Out of scope; single-node focus               |
+| Partial incremental markdown parsing | Requires upstream parser support              |
+
+## 9. Summary
+
+Current design intentionally minimal: rely on OS page cache + lightweight global objects. Only implement additional caching once real workloads demonstrate need.

--- a/request-flow.md
+++ b/request-flow.md
@@ -1,0 +1,90 @@
+# Request Flow & Sequence
+
+> WHY: Clarify branching & data derivation points to aid debugging and performance tuning.
+
+## 1. Index Route (`/`)
+
+```mermaid
+flowchart TB
+  A([GET /]) --> B{index.html exists?}
+  B -->|Yes| C[Read index.html] --> D[200 OK static]
+  B -->|No| E[Build TOC] --> F{TOC ok?}
+  F -->|Err| G[[500 Error]]
+  F -->|Ok| H[md2html TOC] --> I{Render ok?}
+  I -->|Err| G
+  I -->|Ok| J[200 OK rendered TOC]
+```
+
+Notes:
+
+- `Cofg::new()` used once early; config cached.
+- TOC generation frequency expected low; no caching needed initially.
+
+## 2. Generic Path Route (`/{filename:.*}`)
+
+```mermaid
+flowchart TB
+  A([GET /path]) --> B[decoded_uri]
+  B --> C[filename_path]
+  C --> D[public_join]
+  D --> E{File exists?}
+  E -->|No| F[Load 404.html] --> G[[404 Not Found]]
+  E -->|Yes| H{Is .md?}
+  H -->|No| I[Static file] --> J[200 OK static]
+  H -->|Yes| K[Read file]
+  K --> L[md2html path] --> M{Render ok?}
+  M -->|Err| N[[500 Error]]
+  M -->|Ok| O[200 OK HTML]
+```
+
+## 3. md2html Internals
+
+```text
+engine = get_engine(cfg)       # maybe rebuild if hot_reload
+ctx = get_context(cfg)
+for extra var (e.g. path): set_context_value
+ast = parser_md(markdown)
+fragment = render_html(ast)
+ctx.body = fragment
+template = compile_to_bytecode(html-t.templating)
+final_html = render_compiled(template, ctx)
+```
+
+## 4. Per-Request Cache Keys
+
+| Key           | Source Function          | Purpose                                     |
+| ------------- | ------------------------ | ------------------------------------------- |
+| DecodedUri    | `cached_decoded_uri`     | Logging-friendly, percent-decoded path      |
+| FilenamePath  | `cached_filename_path`   | Reusable path param as `PathBuf`            |
+| PublicReqPath | `cached_public_req_path` | Disk resolution anchor under `public_path`  |
+| IsMarkdown    | `cached_is_markdown`     | Branch predicate for dynamic vs static path |
+
+## 5. Error Points & Types
+
+| Stage                   | Potential Error      | AppError Variant       |
+| ----------------------- | -------------------- | ---------------------- |
+| Reading index/markdown  | IO                   | Io                     |
+| TOC glob build/walk     | Pattern / Walk       | GlobPattern / GlobWalk |
+| Markdown parse          | nom errors           | MarkdownParse          |
+| Template compile/render | mystical_runic error | Template               |
+| Config load             | config crate error   | Config                 |
+
+Unhandled bubbles produce 500 via `Responder` impl.
+
+## 6. Timing Hotspots (Potential)
+
+| Area                               | Reason                   | Mitigation Option                        |
+| ---------------------------------- | ------------------------ | ---------------------------------------- |
+| Repeated large markdown parse      | Many hits on large files | Add HTML cache keyed by mtime            |
+| TOC generation on huge trees       | Deep directory structure | Precompute + watch or mtime memoize      |
+| Template engine rebuild (dev only) | hot_reload true          | Acceptable trade-off; keep minimal logic |
+
+## 7. Sequence Summary (Simplified)
+
+```text
+route -> resolve path -> exist?
+  no -> 404 (custom) -> done
+  yes -> md?
+    no -> static file
+    yes -> read -> md2html -> html -> respond
+```

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,10 @@
 //! Unified error types using thiserror
+//!
+//! WHY: Collapse disparate library & IO errors into a small enum convertible to an Actix
+//! Responder—simplifies bubbling errors up from deep helpers (markdown, glob, template) without
+//! sprinkling HTTP response shaping logic throughout.
+//!
+//! 中文：集中管理錯誤型別並直接實作 Responder，讓內層只需 `?` 傳遞，不需關心 HTTP 回應細節。
 
 use log::warn;
 use thiserror::Error;

--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -1,4 +1,10 @@
-//! markdown
+//! Markdown related helpers
+//!
+//! WHY: Keep bulk utilities (batch convert, TOC generation) separated from request path so server
+//! startup & per-request logic remain lean. Functions prefixed with '_' are tooling helpers not
+//! wired into HTTP routes by default.
+//!
+//! 中文：將批次轉換/TOC 邏輯與線上請求分離，保持主流程簡潔；底線開頭為工具函式。
 
 use std::{ fs::{ read_to_string, remove_file, write }, path::Path };
 
@@ -7,6 +13,11 @@ use wax::Glob;
 use crate::{ cofg::Cofg, error, parser::md2html };
 use crate::error::{ AppResult, AppError };
 
+/// Batch convert every `**/*.{md,markdown}` under `public_path` into `.html` siblings.
+///
+/// WHY: Optional build-time / manual utility; not invoked during normal server runtime to avoid
+/// upfront cost. Keeps `md2html` itself pure so we can reuse it in both paths.
+/// 中文：提供選擇性批次轉換工具，不影響伺服器啟動與即時渲染流程。
 pub(crate) fn _md2html_all() -> AppResult<()> {
   let md_files = Glob::new("**/*.{md,markdown}")?;
   let cfg = crate::cofg::Cofg::new(); // returns cached config (not a fresh instance)
@@ -31,6 +42,14 @@ const NON_ALPHANUMERIC: &percent_encoding::AsciiSet = &percent_encoding::NON_ALP
   b'/'
 );
 
+/// Generate an in-memory Markdown TOC listing files with configured extensions under `public_path`.
+///
+/// Each entry becomes `- [stem](percent-encoded-path)`; non-alphanumeric chars percent-encoded
+/// except '/'. Base directory is `toc.path`'s parent to allow placing TOC inside subfolder.
+///
+/// WHY: On-demand generation avoids stale TOC and eliminates pre-bake step. Lightweight glob walk
+/// acceptable since `/` root requests are comparatively infrequent.
+/// 中文：即時產生，避免 TOC 與檔案狀態不一致；根據 toc.path 上層資料夾決定掃描基準。
 pub(crate) fn get_toc(c: &Cofg) -> AppResult<String> {
   let pp = &c.public_path;
 
@@ -63,6 +82,11 @@ pub(crate) fn get_toc(c: &Cofg) -> AppResult<String> {
   Ok(toc_str)
 }
 
+/// Materialize the TOC as HTML file using templating, overwriting existing target.
+///
+/// WHY: Optional pre-generation when running in static hosting scenarios (e.g. CI build) to avoid
+/// computing TOC at runtime.
+/// 中文：可選的預先產生步驟，適合純靜態部署；非伺服器核心流程。
 pub(crate) fn _make_toc() -> AppResult<()> {
   let c = crate::cofg::Cofg::new();
   let pp = &c.public_path;
@@ -77,6 +101,11 @@ pub(crate) fn _make_toc() -> AppResult<()> {
   Ok(())
 }
 
+/// Parse raw markdown into AST using markdown_ppp with default config.
+///
+/// WHY: Encapsulate parser selection & config; caller obtains structured AST for potential future
+/// analysis (currently only rendered directly). Keeps `md2html` simpler.
+/// 中文：抽離解析步驟，未來若需 AST 進階處理可在此擴充。
 pub(crate) fn parser_md(input: String) -> error::AppResult<markdown_ppp::ast::Document> {
   use markdown_ppp::parser::parse_markdown;
   // 內部需要 clone config 給 parser，但外部呼叫時可傳參考，避免重複 clone

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5,8 +5,19 @@ use crate::parser::templating::set_context_value;
 pub(crate) mod markdown;
 pub(crate) mod templating;
 
-/// input md str
-/// return html str
+/// Convert a single markdown string into full HTML page via template `html-t.templating`.
+///
+/// Steps:
+/// 1. Acquire (or rebuild) template engine
+/// 2. Build fresh context (server + configured vars)
+/// 3. Apply extra template_data_list entries (e.g. `path:...`)
+/// 4. Parse markdown → AST → HTML body
+/// 5. Inject `body` then render compiled template
+///
+/// WHY: Keep side effects (engine caching, context assembly) localized while exposing a pure-ish
+/// interface to callers. Accepts owned `md` so upstream can cheaply `read_to_string` and transfer
+/// ownership without clone.
+/// 中文：集中渲染步驟，讓呼叫端只需提供字串與附加變數；擁有字串避免多餘 clone。
 pub(crate) fn md2html(
   md: String,
   c: &crate::cofg::Cofg,

--- a/src/parser/templating.rs
+++ b/src/parser/templating.rs
@@ -1,9 +1,28 @@
-//! templating
+//! Template engine helpers
+//!
+//! WHY: Isolate template engine initialization & context population so markdown → HTML pipeline
+//! stays pure/minimal (`md2html`). Engine instance is cached via `OnceCell<RwLock<_>>` for reuse
+//! (bytecode cache active) unless `hot_reload` signals we must reconstruct to pick up file edits.
+//!
+//! 中文：將模板引擎建構與上下文變數設定集中，讓 `md2html` 保持精簡；常態重用快取以利用
+//! bytecode cache，僅在 hot_reload 啟用時每次重建以反映檔案修改。
 
 use mystical_runic::{ TemplateEngine, TemplateContext };
 use once_cell::sync::OnceCell;
 use std::sync::RwLock;
 
+/// Inject a single `name:value` pair (auto type inference) into template context.
+///
+/// Supported forms:
+/// - `foo:true/false` → bool
+/// - `foo:123` → number (i64)
+/// - `foo:some string` → string
+/// - `foo:env:ENV_NAME` → reads `ENV_NAME` then infers (bool/number/string)
+///
+/// WHY: Allow configuration-driven variable list (`templating.value`) without schema explosion.
+/// Parsing kept intentionally small (no floats) for predictability.
+///
+/// 中文：透過簡單 `name:value` 規則（含 `env:` 展開）注入模板變數，避免為多個旗標打造冗長設定欄位。
 pub(crate) fn set_context_value(context: &mut TemplateContext, data: &str) {
   // Split only at the first ':'; skip malformed entries
   if let Some((name_raw, value_raw)) = data.split_once(':') {
@@ -35,6 +54,14 @@ pub(crate) fn set_context_value(context: &mut TemplateContext, data: &str) {
   } // else: no ':', ignore entry safely
 }
 
+/// Build a fresh template context with server metadata and configured variables.
+///
+/// Always includes `server-version`. Then folds `templating.value` items through
+/// `set_context_value` to infer types.
+///
+/// WHY: Decouple config parsing from render path; context creation is cheap and explicit instead
+/// of sharing mutable state across renders.
+/// 中文：每次渲染建立獨立 context，避免共享可變狀態；同時注入版本資訊與設定變數。
 pub(crate) fn get_context(c: &crate::cofg::Cofg) -> TemplateContext {
   let mut context = TemplateContext::new();
   context.set_string("server-version", env!("CARGO_PKG_VERSION"));
@@ -48,6 +75,14 @@ pub(crate) fn get_context(c: &crate::cofg::Cofg) -> TemplateContext {
 }
 static ENGINE: OnceCell<RwLock<TemplateEngine>> = OnceCell::new();
 
+/// Retrieve (or rebuild under hot reload) the template engine.
+///
+/// On first call, initializes with bytecode cache (and optional hot reload). If `hot_reload` is
+/// true, each call reconstructs a new engine to ensure latest template file contents are used.
+///
+/// WHY: Development ergonomics—trade small rebuild cost for immediacy when editing templates.
+/// Production (no hot_reload) benefits from stable cached engine with bytecode reuse.
+/// 中文：hot_reload 時每次重建以反映檔案變更；否則重用快取獲得效能與 bytecode 優勢。
 pub(crate) fn get_engine(c: &crate::cofg::Cofg) -> TemplateEngine {
   let cell = ENGINE.get_or_init(|| {
     let mut e = TemplateEngine::new("./meta");


### PR DESCRIPTION
### Summary
Add extensive internal documentation and WHY-focused comments to improve maintainability and onboarding.

### Changes
- Add architecture overview (`architecture.md`)
- Add key function rationale (`key-functions.md`)
- Add config ↔ code mapping (`config-templating-map.md`)
- Add request flow diagrams with Mermaid (`request-flow.md`)
- Add performance & caching analysis (`performance-cache.md`)
- Add developer onboarding guide (`developer-guide.md`)
- Insert bilingual WHY doc comments across core modules (`cofg`, `parser`, `templating`, `markdown`, `http_ext`, `main`, `error`)
- Add build.rs (kept from repo context; ensure alignment)

### Rationale
Centralizes tribal knowledge; facilitates future refactors and feature additions (e.g., caching layer, export CLI) by making intent explicit.

### Testing
`cargo nextest run` → 7 tests passed. No functional changes beyond comments/doc additions.

### Follow-ups (Optional)
- Add HTML render cache (mtime keyed) feature flag
- Add path traversal hardening (canonical prefix check)
- Add clippy + markdown lint in CI
- Add `--export` CLI tool for batch static generation

---
Please review wording/style; technical content should be correct per current implementation.
